### PR TITLE
Update Sample app

### DIFF
--- a/Sample/ViewController.swift
+++ b/Sample/ViewController.swift
@@ -42,6 +42,7 @@ class ViewController: UIViewController {
     }
 
     private func startIdentProcess() {
+        self.view.endEditing(true)
         statusView.isHidden = true
 
         do {


### PR DESCRIPTION
Sample app keyboard covered error status description on iPhone 11 screen. I dismiss keyboard when "Start Identification" is pressed to reveal text.